### PR TITLE
Tracking functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ $ gem install pushpop-keen
 
 ### Usage
 
+#### Querying 
+
 The `keen` plugin gives you a DSL to specify Keen query parameters. Those query parameters are used to query data using the [keen-gem](https://github.com/keenlabs/keen-gem).
 
 Here's an example that shows many of the options you can specify:
@@ -42,6 +44,20 @@ end
 
 A `steps` method is also supported for [funnels](https://keen.io/docs/data-analysis/funnels/),
 as well as `analyses` for doing a [multi-analysis](https://keen.io/docs/data-analysis/multi-analysis/).
+
+#### Tracking
+
+You can also very simply record events to Keen:
+
+``` ruby
+job 'send pageview'
+  
+  keen do
+    record 'Pageview', path: '/a/path'   
+  end
+
+end
+```
 
 The `keen` plugin requires that the following environment variables are set:
   

--- a/lib/pushpop-keen.rb
+++ b/lib/pushpop-keen.rb
@@ -20,16 +20,23 @@ module Pushpop
     attr_accessor :_analyses
 
     def run(last_response=nil, step_responses=nil)
-      self.configure(last_response, step_responses)
+      ret = self.configure(last_response, step_responses)
+
       if self._analysis_type == 'funnel'
         ::Keen.funnel(self.to_analysis_options)
-      else
+      elsif !self._analysis_type.nil?
         ::Keen.send(self._analysis_type, self._event_collection, self.to_analysis_options)
+      else
+        ret
       end
     end
 
     def configure(last_response=nil, step_responses=nil)
       self.instance_exec(last_response, step_responses, &block)
+    end
+
+    def record(name, properties)
+      ::Keen.publish(name, properties)
     end
 
     def to_analysis_options

--- a/spec/pushpop-keen_spec.rb
+++ b/spec/pushpop-keen_spec.rb
@@ -37,6 +37,17 @@ describe Pushpop::Keen do
 
   end
 
+  describe '#record' do
+    it 'should record an event with properties' do
+      step = Pushpop::Keen.new do
+        record 'Pageview', useragent: 'Chrome'
+      end
+
+      expect(Keen).to receive(:publish).with('Pageview', useragent: 'Chrome')
+      step.run
+    end
+  end
+
   describe '#run' do
     it 'should run the query based on the analysis type' do
       Keen.stub(:count).with('pageviews', {
@@ -50,6 +61,17 @@ describe Pushpop::Keen do
       end
       response = step.run
       response.should == 365
+    end
+
+    it 'should not try to run a query if the analysis type isnt set' do
+      step = Pushpop::Keen.new do
+        group_by 'something'
+      end
+
+      expect(Keen).not_to receive(:send)
+      expect(Keen).not_to receive(:funnel)
+
+      step.run
     end
 
     it 'should run funnels directly, instead of using send' do


### PR DESCRIPTION
@hex337 @tushdante This is pretty simple... it just wraps the `publish` function in a `record` method (which is apparently the verb we are supposed to use now).